### PR TITLE
Rename `ScopedPottery` and `LocalPots` to `LocalPottery` and `LocalPotteryObjects`

### DIFF
--- a/packages/pottery/README.md
+++ b/packages/pottery/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-A package that provides two widgets, `Pottery` and `ScopedPottery`.
+A package that provides two widgets, `Pottery` and `LocalPottery`.
 
 They limit the scope where particular [Pot]s are available in the widget tree.
 Using them make it clearer from which point onwards pots are used.
@@ -46,7 +46,7 @@ dependencies:
 This package comes with two widgets:
 
 - [Pottery]
-- [ScopedPottery]
+- [LocalPottery]
 
 ### Pottery
 
@@ -100,15 +100,15 @@ Removing Pottery from the tree (e.g. navigating back from the page where Pottery
 resets all pots in the `pots` map and replaces their factories to throw an
 [PotNotReadyException].
 
-### ScopedPottery
+### LocalPottery
 
-This widget defines new factories for existing pots and binds the objects created by
-them to the pots so that those objects are made available to descendants.
+This widget defines new factories for existing pots to create objects that are available
+only in the subtree.
 
-An important fact is that the factories of the existing pots are not actually replaced,
-therefore calling the [call()] method of a pot still returns the object held in the
-global pot. Use [of()] instead to obtain the scoped object. The example below illustrates
-the behaviour.
+An important fact is that the factories of the existing pots are not replaced, but
+new factories are associated with those pots. Therefore, calling the [call()] method
+of a pot still returns the object held in the global pot. Use [of()] instead to obtain
+the local object. The example below illustrates the behaviour.
 
 ```dart
 final fooPot = Pot(() => Foo(111));
@@ -118,7 +118,7 @@ final fooPot = Pot(() => Foo(111));
 class ParentWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return ScopedPottery(
+    return LocalPottery(
       pots: {
         fooPot: () => Foo(222),
       },
@@ -142,18 +142,32 @@ class ChildWidget extends StatelessWidget {
 }
 ```
 
-See the examples in [main2.dart] and in the document of [ScopedPottery] for usage in
+See the examples in [main2.dart] and in the document of [LocalPottery] for usage in
 more practical use cases.
 
-Note that there are several important differences between `ScopedPottery` and [Pottery]:
+Note that there are several important differences between `LocalPottery` and [Pottery]:
 
-- Objects are created immediately when `ScopedPottery` is created, not when objects
+- Objects are created immediately when `LocalPottery` is created, not when objects
   in Pots are accessed for the first time.
-- As already mentioned, objects created with `ScopedPottery` are only accessible with
+- As already mentioned, objects created with `LocalPottery` are only accessible with
   [of()].
-- Objects created with `ScopedPottery` are not automatically discarded when the
-  `ScopedPottery` is removed from the tree. Use the `disposer` argument to specify a
-  callback function to clean them up.
+- Objects created with `LocalPottery` are not automatically discarded when the
+  `LocalPottery` is removed from the tree. Use the `disposer` argument to specify a
+  callback function to clean them up. Below is an example where the disposer function
+  disposes of all ChangeNotifier subtypes.
+
+```dart
+LocalPottery(
+  pots: {
+    myChangeNotifier: () => MyChangeNotifier(),
+    intValueNotifier: () => ValueNotifier(111),
+  },
+  disposer: (pots) {
+    pots.values.whereType<ChangeNotifier>().forEach((v) => v.dispose());
+  },
+  builder: (context) { ... },
+)
+```
 
 ## Caveats
 
@@ -279,7 +293,7 @@ ElevatedButton(
 <!-- Links -->
 
 [Pottery]: https://pub.dev/documentation/pottery/latest/pottery/Pottery-class.html
-[ScopedPottery]: https://pub.dev/documentation/pottery/latest/pottery/ScopedPottery-class.html
+[LocalPottery]: https://pub.dev/documentation/pottery/latest/pottery/LocalPottery-class.html
 [of()]: https://pub.dev/documentation/pottery/latest/pottery/NearestPotOf/of.html
 [call()]: https://pub.dev/documentation/pot/latest/pot/Pot/call.html
 [Pot]: https://pub.dev/packages/pot

--- a/packages/pottery/example/README.md
+++ b/packages/pottery/example/README.md
@@ -3,9 +3,9 @@
 - **[main.dart]**
     - Counter using [Pottery]
 - **[main2.dart]**
-    - List of counters using [ScopedPottery]
+    - List of counters using [LocalPottery]
 
 [main.dart]: https://github.com/kaboc/pot/blob/main/packages/pottery/example/lib/main.dart
 [main2.dart]: https://github.com/kaboc/pot/blob/main/packages/pottery/example/lib/main2.dart
 [Pottery]: https://pub.dev/documentation/pottery/latest/pottery/Pottery-class.html
-[ScopedPottery]: https://pub.dev/documentation/pottery/latest/pottery/ScopedPottery-class.html
+[LocalPottery]: https://pub.dev/documentation/pottery/latest/pottery/LocalPottery-class.html

--- a/packages/pottery/example/lib/main2.dart
+++ b/packages/pottery/example/lib/main2.dart
@@ -32,16 +32,16 @@ class App extends StatelessWidget {
               child: Column(
                 children: [
                   for (var i = 0; i < 50; i++)
-                    ScopedPottery(
+                    LocalPottery(
                       pots: {
                         indexPot: () => i,
-                        // A scoped notifier is provided to the descendant
+                        // A different notifier is provided to the subtree
                         // when the index is an odd number.
                         if (i.isOdd) counterPot: HyperCounterNotifier.new,
                       },
                       disposer: (pots) {
                         // It is your responsibility to dispose of the
-                        // objects created by ScopedPottery.
+                        // objects created by LocalPottery.
                         (pots[counterPot] as CounterNotifier?)?.dispose();
                       },
                       builder: (context) {
@@ -70,8 +70,8 @@ class App extends StatelessWidget {
 
 class _Item extends StatelessWidget with Grab {
   // This widget is const with no parameter.
-  // It is possible because of ScopedPottery and `of()`.
-  // The index and other values are obtained from the ScopedPottery above.
+  // It is possible because of LocalPottery and `of()`.
+  // The index and other values are obtained from the LocalPottery above.
   const _Item();
 
   @override

--- a/packages/pottery/lib/pottery.dart
+++ b/packages/pottery/lib/pottery.dart
@@ -1,4 +1,4 @@
+export 'src/local_pottery.dart';
 export 'src/pottery.dart';
-export 'src/scoped_pottery.dart';
 
 export 'package:pot/pot.dart';

--- a/packages/pottery/lib/src/local_pottery.dart
+++ b/packages/pottery/lib/src/local_pottery.dart
@@ -16,7 +16,7 @@ typedef ScopedPottery = LocalPottery;
 typedef PotOverrides = Map<Pot<Object?>, PotObjectFactory<Object?>>;
 
 /// The signature of a map consisting of pots and the objects they hold.
-typedef LocalPots = Map<Pot<Object?>, Object?>;
+typedef LocalPotteryObjects = Map<Pot<Object?>, Object?>;
 
 /// A widget that associates existing pots with new values and makes
 /// them accessible from descendants in the tree via the pots.
@@ -167,27 +167,27 @@ class LocalPottery extends StatefulWidget {
   /// to the [pots] argument. Use this disposer to specify a callback
   /// function to clean up the objects like ValueNotifiers, which are
   /// supposed to be disposed of when no longer used.
-  final void Function(LocalPots)? disposer;
+  final void Function(LocalPotteryObjects)? disposer;
 
   @override
   State<LocalPottery> createState() => _LocalPotteryState();
 }
 
 class _LocalPotteryState extends State<LocalPottery> {
-  late final LocalPots _localPots;
+  late final LocalPotteryObjects _objects;
 
   @override
   void initState() {
     super.initState();
 
-    _localPots = {
+    _objects = {
       for (final entry in widget.pots.entries) entry.key: entry.value(),
     };
   }
 
   @override
   void dispose() {
-    widget.disposer?.call(_localPots);
+    widget.disposer?.call(_objects);
     super.dispose();
   }
 
@@ -199,7 +199,8 @@ class _LocalPotteryState extends State<LocalPottery> {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<LocalPots>('localPots', _localPots));
+    properties
+        .add(DiagnosticsProperty<LocalPotteryObjects>('objects', _objects));
   }
 }
 
@@ -208,7 +209,7 @@ extension NearestPotOf<T> on Pot<T> {
   MapEntry<Pot<Object?>, Object?>? _findEntry(BuildContext context) {
     if (context.widget is LocalPottery) {
       final state = (context as StatefulElement).state;
-      final pots = (state as _LocalPotteryState)._localPots;
+      final pots = (state as _LocalPotteryState)._objects;
 
       for (final entry in pots.entries) {
         if (entry.key == this) {

--- a/packages/pottery/lib/src/local_pottery.dart
+++ b/packages/pottery/lib/src/local_pottery.dart
@@ -9,12 +9,12 @@ import 'pottery.dart';
 typedef PotOverrides = Map<Pot<Object?>, PotObjectFactory<Object?>>;
 
 /// The signature of a map consisting of pots and the objects they hold.
-typedef ScopedPots = Map<Pot<Object?>, Object?>;
+typedef LocalPots = Map<Pot<Object?>, Object?>;
 
 /// A widget that associates existing pots with new values and makes
 /// them accessible from descendants in the tree via the pots.
 ///
-/// {@template scopedPottery.class}
+/// {@template localPottery.class}
 /// This widget defines new factories for existing pots and binds the
 /// objects created by them to the pots so that those objects are made
 /// available to descendants.
@@ -22,8 +22,8 @@ typedef ScopedPots = Map<Pot<Object?>, Object?>;
 /// An important fact is that the factories of the existing pots are
 /// not actually replaced, therefore calling the [Pot.call] method
 /// still returns the object held in the global pot. Use [NearestPotOf.of]
-/// instead to obtain the scoped object. The example below illustrates
-/// the behaviour.
+/// instead to obtain the local object from the nearest `LocalPottery`
+/// ancestor. The example below illustrates the behaviour.
 ///
 /// ```dart
 /// final fooPot = Pot(() => Foo(111));
@@ -33,7 +33,7 @@ typedef ScopedPots = Map<Pot<Object?>, Object?>;
 /// class ParentWidget extends StatelessWidget {
 ///   @override
 ///   Widget build(BuildContext context) {
-///     return ScopedPottery(
+///     return LocalPottery(
 ///       pots: {
 ///         fooPot: () => Foo(222),
 ///       },
@@ -60,7 +60,7 @@ typedef ScopedPots = Map<Pot<Object?>, Object?>;
 /// This is useful when you need in descendants some objects that are
 /// different from the ones held in global pots but of the same type.
 ///
-/// In the following example, a `ScopedPottery` provides its descendant
+/// In the following example, a `LocalPottery` provides its descendant
 /// (TodoListPage) with a notifier for a specific category. It allows
 /// the previous page to control which category the next page is
 /// associated with.
@@ -77,7 +77,7 @@ typedef ScopedPots = Map<Pot<Object?>, Object?>;
 ///
 ///   static Route<void> route({required Category category}) {
 ///     return MaterialPageRoute(
-///       builder: (context) => ScopedPottery(
+///       builder: (context) => LocalPottery(
 ///         pots: {
 ///           todosNotifierPot: () => TodosNotifierPot(category: category),
 ///         },
@@ -109,32 +109,32 @@ typedef ScopedPots = Map<Pot<Object?>, Object?>;
 /// ```
 ///
 /// Note that there are several important differences between
-/// `ScopedPottery` and [Pottery]:
+/// `LocalPottery` and [Pottery]:
 ///
-/// * Objects are created in [Pot]s as soon as `ScopedPottery` is
-///   created, whereas in `Pottery`, objects are created (replaced,
-///   more precisely) only if Pots already have ones.
-/// * As already mentioned, objects created by `ScopedPottery` are
+/// * `LocalPottery` creates an object immediately, whereas
+///   `Pottery` creates (replaces, more precisely) an object only
+///   if the relevant Pot already have one.
+/// * As already mentioned, objects created by `LocalPottery` are
 ///   only accessible with [NearestPotOf.of].
-/// * Objects created by `ScopedPottery` are not automatically
-///   discarded when the `ScopedPottery` is removed from the tree.
+/// * Objects created by `LocalPottery` are not automatically
+///   discarded when the `LocalPottery` is removed from the tree.
 ///   Use [disposer] to do clean-up.
 ///
 /// Also note that an error arises only at runtime if the map
 /// contains wrong pairs of pot and factory. Make sure to specify
 /// a correct factory creating an object of the correct type.
 ///
-/// It is advised that `ScopedPottery` be used only where it is
+/// It is advised that `LocalPottery` be used only where it is
 /// absolutely necessary. Using it too much may make it harder to
 /// follow the code of your app.
 /// {@endtemplate}
-class ScopedPottery extends StatefulWidget {
-  /// Creates a [ScopedPottery] widget that associates existing pots
+class LocalPottery extends StatefulWidget {
+  /// Creates a [LocalPottery] widget that associates existing pots
   /// with new values and makes them accessible from descendants in
   /// the tree via the pots.
   ///
-  /// {@macro scopedPottery.class}
-  const ScopedPottery({
+  /// {@macro localPottery.class}
+  const LocalPottery({
     super.key,
     required this.pots,
     required this.builder,
@@ -144,41 +144,43 @@ class ScopedPottery extends StatefulWidget {
   /// A map of pots and factories.
   ///
   /// The factories are called immediately to create objects when
-  /// the [ScopedPottery] is created. The objects are accessible
-  /// with [NearestPotOf.of] (not with [Pot.call]) from the descendants.
+  /// the [LocalPottery] is created. The objects are accessible
+  /// with [NearestPotOf.of] (not with [Pot.call]) from the
+  /// descendants.
   final PotOverrides pots;
 
   /// A function called to obtain the child widget.
   final WidgetBuilder builder;
 
-  /// A function called when this [ScopedPottery] is removed from
+  /// A function called when this [LocalPottery] is removed from
   /// the tree permanently.
   ///
-  /// [ScopedPottery], unlike [Pottery], does not automatically
+  /// [LocalPottery], unlike [Pottery], does not automatically
   /// discard the objects that were created by the factories passed
   /// to the [pots] argument. Use this disposer to specify a callback
   /// function to clean up the objects like ValueNotifiers, which are
   /// supposed to be disposed of when no longer used.
-  final ValueSetter<ScopedPots>? disposer;
+  final void Function(LocalPots)? disposer;
 
   @override
-  State<ScopedPottery> createState() => _ScopedPotteryState();
+  State<LocalPottery> createState() => _LocalPotteryState();
 }
 
-class _ScopedPotteryState extends State<ScopedPottery> {
-  late final ScopedPots _scopedPots;
+class _LocalPotteryState extends State<LocalPottery> {
+  late final LocalPots _localPots;
 
   @override
   void initState() {
     super.initState();
-    _scopedPots = {
+
+    _localPots = {
       for (final entry in widget.pots.entries) entry.key: entry.value(),
     };
   }
 
   @override
   void dispose() {
-    widget.disposer?.call(_scopedPots);
+    widget.disposer?.call(_localPots);
     super.dispose();
   }
 
@@ -190,16 +192,16 @@ class _ScopedPotteryState extends State<ScopedPottery> {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<ScopedPots>('scopedPots', _scopedPots));
+    properties.add(DiagnosticsProperty<LocalPots>('localPots', _localPots));
   }
 }
 
-/// Extension on [Pot] used in relation to [ScopedPottery].
+/// Extension on [Pot] used in relation to [LocalPottery].
 extension NearestPotOf<T> on Pot<T> {
   MapEntry<Pot<Object?>, Object?>? _findEntry(BuildContext context) {
-    if (context.widget is ScopedPottery) {
+    if (context.widget is LocalPottery) {
       final state = (context as StatefulElement).state;
-      final pots = (state as _ScopedPotteryState)._scopedPots;
+      final pots = (state as _LocalPotteryState)._localPots;
 
       for (final entry in pots.entries) {
         if (entry.key == this) {
@@ -215,26 +217,26 @@ extension NearestPotOf<T> on Pot<T> {
   }
 
   /// An extension method of [Pot] that recursively visits ancestors
-  /// to find the nearest [ScopedPottery] and obtains the object bound
+  /// to find the nearest [LocalPottery] and obtains the object bound
   /// locally to the pot.
   ///
   /// If the pot which this method is called on is contained as a key
-  /// in the `pots` map of a [ScopedPottery] located up in the tree,
+  /// in the `pots` map of a [LocalPottery] located up in the tree,
   /// the value corresponding to the key is obtained from there.
   ///
-  /// If no such `ScopedPottery` is found, the object held in the global
+  /// If no such `LocalPottery` is found, the object held in the global
   /// pot is returned, in which case, the return value is the same as
   /// that of the [Pot.call] method.
   ///
-  /// See the document of [ScopedPottery] for usage.
+  /// See the document of [LocalPottery] for usage.
   ///
   /// Note that calling this method is relatively expensive (O(N) in
   /// the depth of the tree). Only call it if the distance from the
   /// widget associated with the [BuildContext] to the desired ancestor
   /// is known to be small and bounded.
   T of(BuildContext context) {
-    // Targets the current BuildContext too so that the scoped pot
-    // becomes available from within the builder callback.
+    // Targets the current BuildContext too so that the local objects
+    // become available from within the builder callback.
     var entry = _findEntry(context);
 
     if (entry == null) {

--- a/packages/pottery/lib/src/local_pottery.dart
+++ b/packages/pottery/lib/src/local_pottery.dart
@@ -5,6 +5,13 @@ import 'package:pot/pot.dart';
 
 import 'pottery.dart';
 
+/// An alias of [LocalPottery].
+@Deprecated(
+  'Use LocalPottery instead. '
+  'This was deprecated as of pottery 0.2.0.',
+)
+typedef ScopedPottery = LocalPottery;
+
 /// The signature of a map consisting of pots and factories.
 typedef PotOverrides = Map<Pot<Object?>, PotObjectFactory<Object?>>;
 

--- a/packages/pottery/lib/src/pottery.dart
+++ b/packages/pottery/lib/src/pottery.dart
@@ -3,7 +3,7 @@ import 'package:flutter/widgets.dart';
 
 import 'package:pot/pot.dart';
 
-import 'scoped_pottery.dart';
+import 'local_pottery.dart';
 
 /// The signature of a map consisting of replaceable pots and factories.
 typedef PotReplacements
@@ -48,7 +48,7 @@ typedef PotReplacements
 /// Note that [Pottery] does not bind pots to the widget tree.
 /// It only uses the lifecycle of itself in the tree to control
 /// the lifespan of pots' content, which is an important difference
-/// from [ScopedPottery].
+/// from [LocalPottery].
 ///
 /// Also note that an error arises only at runtime if the map
 /// contains wrong pairs of pot and factory. Make sure to specify

--- a/packages/pottery/test/local_pottery_test.dart
+++ b/packages/pottery/test/local_pottery_test.dart
@@ -27,7 +27,7 @@ void main() {
   });
 
   testWidgets(
-    'Pots provided by nearest ScopedPottery are obtained with `of()`',
+    'Pots provided by nearest LocalPottery are obtained with `of()`',
     (tester) async {
       fooPot = Pot.pending<Foo>();
       barPot = Pot.pending<Bar>();
@@ -37,7 +37,7 @@ void main() {
 
       var called = false;
       await tester.pumpWidget(
-        TestScopedPottery(
+        TestLocalPottery(
           pots: {
             fooPot!: Foo.new,
           },
@@ -70,7 +70,7 @@ void main() {
       Foo? foo1;
       Foo? foo2;
       await tester.pumpWidget(
-        TestScopedPottery(
+        TestLocalPottery(
           pots: {
             fooPot!: () => const Foo(20),
           },
@@ -92,7 +92,7 @@ void main() {
 
     var isNullObtained = false;
     await tester.pumpWidget(
-      TestScopedPottery(
+      TestLocalPottery(
         pots: {
           nullablePot!: () => null,
         },
@@ -106,8 +106,8 @@ void main() {
   });
 
   testWidgets(
-    'Disposer of pot is not called when ScopedPottery is removed, '
-    'while disposer of ScopedPottery is called with correct map',
+    'Disposer of pot is not called when LocalPottery is removed, '
+    'while disposer of LocalPottery is called with correct map',
     (tester) async {
       var globallyDisposed = false;
       fooPot = Pot.replaceable(
@@ -118,9 +118,9 @@ void main() {
 
       fooPot?.create();
 
-      ScopedPots? map;
+      LocalPots? map;
       await tester.pumpWidget(
-        TestScopedPottery(
+        TestLocalPottery(
           pots: {
             fooPot!: () => const Foo(20),
             barPot!: () => const Bar(),
@@ -144,7 +144,7 @@ void main() {
     },
   );
 
-  testWidgets('Multiple ScopedPotteries as siblings', (tester) async {
+  testWidgets('Multiple LocalPottery as siblings', (tester) async {
     fooPot = Pot.pending<Foo>();
 
     Foo? foo1;
@@ -154,7 +154,7 @@ void main() {
     await tester.pumpWidget(
       Column(
         children: [
-          TestScopedPottery(
+          TestLocalPottery(
             pots: {
               fooPot!: () => const Foo(10),
             },
@@ -168,7 +168,7 @@ void main() {
               );
             },
           ),
-          TestScopedPottery(
+          TestLocalPottery(
             pots: {
               fooPot!: () => const Foo(20),
             },
@@ -192,7 +192,7 @@ void main() {
     expect(foo4?.value, 20);
   });
 
-  testWidgets('Nested ScopedPotteries', (tester) async {
+  testWidgets('Nested LocalPottery', (tester) async {
     fooPot = Pot.pending<Foo>();
 
     Foo? foo1;
@@ -200,7 +200,7 @@ void main() {
     Foo? foo3;
     Foo? foo4;
     await tester.pumpWidget(
-      TestScopedPottery(
+      TestLocalPottery(
         pots: {
           fooPot!: () => const Foo(10),
         },
@@ -209,7 +209,7 @@ void main() {
           return Descendant(
             builder: (context2) {
               foo2 = fooPot?.of(context2);
-              return TestScopedPottery(
+              return TestLocalPottery(
                 pots: {
                   fooPot!: () => const Foo(20),
                 },
@@ -244,8 +244,8 @@ void main() {
 
     final key = GlobalKey();
     await tester.pumpWidget(
-      TestScopedPottery(
-        scopedPotteryKey: key,
+      TestLocalPottery(
+        localPotteryKey: key,
         pots: {
           fooPot!: () => foo,
           barPot!: () => bar,
@@ -260,6 +260,6 @@ void main() {
         if (prop.name != null) prop.name: prop.value,
     };
 
-    expect(props['scopedPots'], equals({fooPot: foo, barPot: bar}));
+    expect(props['localPots'], equals({fooPot: foo, barPot: bar}));
   });
 }

--- a/packages/pottery/test/local_pottery_test.dart
+++ b/packages/pottery/test/local_pottery_test.dart
@@ -118,7 +118,7 @@ void main() {
 
       fooPot?.create();
 
-      LocalPots? map;
+      LocalPotteryObjects? map;
       await tester.pumpWidget(
         TestLocalPottery(
           pots: {
@@ -260,6 +260,6 @@ void main() {
         if (prop.name != null) prop.name: prop.value,
     };
 
-    expect(props['localPots'], equals({fooPot: foo, barPot: bar}));
+    expect(props['objects'], equals({fooPot: foo, barPot: bar}));
   });
 }

--- a/packages/pottery/test/widgets.dart
+++ b/packages/pottery/test/widgets.dart
@@ -43,24 +43,24 @@ class _TestPotteryState extends State<TestPottery> {
   }
 }
 
-class TestScopedPottery extends StatefulWidget {
-  const TestScopedPottery({
-    this.scopedPotteryKey,
+class TestLocalPottery extends StatefulWidget {
+  const TestLocalPottery({
+    this.localPotteryKey,
     required this.pots,
     this.disposer,
     this.builder,
   });
 
-  final GlobalKey<Object?>? scopedPotteryKey;
+  final GlobalKey<Object?>? localPotteryKey;
   final PotReplacements pots;
   final WidgetBuilder? builder;
-  final ValueSetter<ScopedPots>? disposer;
+  final void Function(LocalPots)? disposer;
 
   @override
-  State<TestScopedPottery> createState() => _TestScopedPotteryState();
+  State<TestLocalPottery> createState() => _TestLocalPotteryState();
 }
 
-class _TestScopedPotteryState extends State<TestScopedPottery> {
+class _TestLocalPotteryState extends State<TestLocalPottery> {
   bool _pressed = false;
 
   @override
@@ -70,8 +70,8 @@ class _TestScopedPotteryState extends State<TestScopedPottery> {
       child: Column(
         children: [
           if (!_pressed)
-            ScopedPottery(
-              key: widget.scopedPotteryKey,
+            LocalPottery(
+              key: widget.localPotteryKey,
               pots: widget.pots,
               disposer: widget.disposer,
               builder: widget.builder ?? (_) => const SizedBox.shrink(),

--- a/packages/pottery/test/widgets.dart
+++ b/packages/pottery/test/widgets.dart
@@ -54,7 +54,7 @@ class TestLocalPottery extends StatefulWidget {
   final GlobalKey<Object?>? localPotteryKey;
   final PotReplacements pots;
   final WidgetBuilder? builder;
-  final void Function(LocalPots)? disposer;
+  final void Function(LocalPotteryObjects)? disposer;
 
   @override
   State<TestLocalPottery> createState() => _TestLocalPotteryState();


### PR DESCRIPTION
Closes #6

`ScopedPottery` remains, but is now as an alias of `LocalPottery`. It is marked as deprecated and will be removed in the future.