### PR TITLE
Add `listen()` to Pot

### DIFF
--- a/packages/pot/README.md
+++ b/packages/pot/README.md
@@ -189,6 +189,26 @@ void main() {
 }
 ```
 
+### Listening for events
+
+The static method `listen()` allows you to listen for events related to pots.
+
+```dart
+final removeListener = Pot.listen((event) {
+  ...
+});
+
+// Don't forget to stop listening when it is no longer necessary.
+removeListener();
+```
+
+Note:
+- Events of changes in the objects held in pots are not emitted automatically.
+    - Call `notifyObjectUpdate()` to manually emit those events if necessary.
+- There is no guarantee that the event data format remains unchanged in the
+  future. Use the method and the data passed to the callback function only
+  for debugging purposes.
+
 ### Scoping
 
 A "scope" in this package is a notion related to the lifespan of an object held in a pot.

--- a/packages/pot/lib/src/event/controller.dart
+++ b/packages/pot/lib/src/event/controller.dart
@@ -1,0 +1,48 @@
+part of '../pot.dart';
+
+class _EventController {
+  StreamController<PotEvent>? _streamController;
+  int _number = 0;
+
+  bool get hasListener => _streamController?.hasListener ?? false;
+
+  Future<void> _closeStreamController() async {
+    await _streamController?.close();
+    _streamController = null;
+  }
+
+  RemovePotListener listen(void Function(PotEvent event) onData) {
+    _streamController ??= StreamController<PotEvent>.broadcast();
+    final subscription = _streamController?.stream.listen(onData);
+    return () async {
+      await subscription?.cancel();
+
+      final controller = _streamController;
+      if (controller != null && !controller.hasListener) {
+        await _closeStreamController();
+      }
+    };
+  }
+
+  void addEvent(
+    PotEventKind kind, {
+    required Iterable<_PotBody<Object?>> pots,
+  }) {
+    final controller = _streamController;
+    if (controller == null || !controller.hasListener) {
+      return;
+    }
+
+    controller.sink.add(
+      PotEvent(
+        number: ++_number,
+        kind: kind,
+        time: DateTime.now(),
+        currentScope: Pot.currentScope,
+        potDescriptions: [
+          for (final pot in pots) PotDescription.fromPot(pot as Pot),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/pot/lib/src/event/controller.dart
+++ b/packages/pot/lib/src/event/controller.dart
@@ -5,6 +5,7 @@ class _EventController {
   int _number = 0;
 
   bool get hasListener => _streamController?.hasListener ?? false;
+  bool get isClosed => _streamController?.isClosed ?? true;
 
   Future<void> _closeStreamController() async {
     await _streamController?.close();

--- a/packages/pot/lib/src/event/data.dart
+++ b/packages/pot/lib/src/event/data.dart
@@ -1,0 +1,214 @@
+part of '../pot.dart';
+
+/// The types of events that can occur in relation to [Pot].
+enum PotEventKind {
+  /// A value that represents an unknown event.
+  unknown,
+
+  /// A value that represents an event when a [Pot] was instantiated.
+  instantiated,
+
+  /// A value that represents an event when an object was created in a [Pot].
+  created,
+
+  /// A value that represents an event when the factory of a [Pot] was replaced.
+  replaced,
+
+  /// A value that represents an event when a [Pot] was reset.
+  reset,
+
+  /// A value that represents an event when the disposer of a [Pot] was called.
+  disposerCalled,
+
+  /// A value that represents an event when a [Pot] was marked as pending.
+  markedAsPending,
+
+  /// A value that represents an event when a [Pot] was disposed.
+  disposed,
+
+  /// A value that represents an event when a new scope was created.
+  scopePushed,
+
+  /// A value that represents an event when all [Pot]s in a scope were reset.
+  scopeCleared,
+
+  /// A value that represents an event when all [Pot]s in a scope were reset
+  /// and the scope was removed.
+  scopePopped,
+
+  /// A value that represents an event when a [Pot] was associated with the
+  /// current scope.
+  addedToScope,
+
+  /// A value that represents an event when a [Pot] was unassociated from
+  /// a scope.
+  removedFromScope,
+
+  /// A value that represents an event when the object held in a [Pot] was
+  /// updated.
+  objectUpdated,
+
+  /// A value that represents an event when a `Pottery` of package:pottery
+  /// was inserted into the tree.
+  potteryCreated,
+
+  /// A value that represents an event when a `Pottery` of package:pottery
+  /// was removed from the tree.
+  potteryRemoved,
+
+  /// A value that represents an event when a `LocalPottery` of
+  /// package:pottery was inserted into the tree.
+  localPotteryCreated,
+
+  /// A value that represents an event when a `LocalPottery` of
+  /// package:pottery was removed from the tree.
+  localPotteryRemoved,
+}
+
+/// A class that represents an event related to [Pot].
+class PotEvent {
+  /// Creates a [PotEvent] that represents an event related to [Pot].
+  const PotEvent({
+    required this.number,
+    required this.kind,
+    required this.time,
+    required this.currentScope,
+    required this.potDescriptions,
+  });
+
+  /// Creates a PotEvent from a Map.
+  factory PotEvent.fromMap(Map<String, Object?> map) {
+    final kindName = map['kind'] as String? ?? '';
+    final descriptions = map['potDescriptions'] as List<Object?>? ?? [];
+
+    return PotEvent(
+      number: map['number'] as int? ?? 0,
+      kind: PotEventKind.values.asNameMap()[kindName] ?? PotEventKind.unknown,
+      time: DateTime.fromMicrosecondsSinceEpoch(map['time'] as int? ?? 0),
+      currentScope: map['currentScope'] as int? ?? 0,
+      potDescriptions: [
+        for (final desc in descriptions)
+          if (desc != null)
+            PotDescription.fromMap(desc as Map<String, Object?>),
+      ],
+    );
+  }
+
+  /// A sequence number.
+  final int number;
+
+  /// The kind of the event.
+  final PotEventKind kind;
+
+  /// The time when the event occurred.
+  final DateTime time;
+
+  /// The number of the scope as of when the event occurred.
+  final int currentScope;
+
+  /// The details of the pot where the event occurred.
+  final List<PotDescription> potDescriptions;
+
+  @override
+  String toString() {
+    return 'PotEvent('
+        'number: $number, '
+        'kind: ${kind.name}, '
+        'time: $time, '
+        'currentScope: $currentScope, '
+        // ignore: missing_whitespace_between_adjacent_strings
+        'potDescriptions: [${potDescriptions.map((v) => '$v').join(', ')}]'
+        ')';
+  }
+
+  /// Converts a [PotEvent] to a Map.
+  Map<String, Object?> toMap() {
+    return {
+      'number': number,
+      'kind': kind.name,
+      'time': time.microsecondsSinceEpoch,
+      'currentScope': currentScope,
+      'potDescriptions': [
+        for (final desc in potDescriptions) desc.toMap(),
+      ],
+    };
+  }
+}
+
+/// A class that describes the details of a [Pot].
+class PotDescription {
+  /// Creates a [PotDescription] that describes the details of a [Pot].
+  const PotDescription({
+    required this.identity,
+    required this.isPending,
+    required this.isDisposed,
+    required this.hasObject,
+    required this.object,
+    required this.scope,
+  });
+
+  /// Creates a [PotDescription] from a Map.
+  factory PotDescription.fromMap(Map<String, Object?> map) {
+    return PotDescription(
+      identity: map['identity'] as String? ?? '',
+      isPending: map['isPending'] as bool?,
+      isDisposed: map['isDisposed'] as bool? ?? false,
+      hasObject: map['hasObject'] as bool? ?? false,
+      object: map['object'] as String? ?? '',
+      scope: map['scope'] as int?,
+    );
+  }
+
+  /// Creates a [PotDescription] from a Pot.
+  factory PotDescription.fromPot(Pot<Object?> pot) {
+    return PotDescription(
+      identity: pot.$identity(),
+      isPending: pot is ReplaceablePot ? pot.isPending : null,
+      isDisposed: pot._isDisposed,
+      hasObject: pot._hasObject,
+      object: '${pot._object}',
+      scope: pot._scope,
+    );
+  }
+
+  /// A summary of the runtime type and hash code of the pot.
+  final String identity;
+
+  /// Whether the pot is in the state of pending.
+  final bool? isPending;
+
+  /// Whether the pot has already been disposed.
+  final bool isDisposed;
+
+  /// Whether an object has been created in the pot.
+  final bool hasObject;
+
+  /// The object held in the pot.
+  final String object;
+
+  /// The number of the scope the pot is bound to.
+  final int? scope;
+
+  @override
+  String toString() {
+    return '$identity('
+        'isPending: $isPending, '
+        'isDisposed: $isDisposed, '
+        'hasObject: $hasObject, '
+        'object: $object, '
+        'scope: $scope'
+        ')';
+  }
+
+  /// Converts a [PotDescription] to a Map.
+  Map<String, Object?> toMap() {
+    return {
+      'identity': identity,
+      'isPending': isPending,
+      'isDisposed': isDisposed,
+      'hasObject': hasObject,
+      'object': object,
+      'scope': scope,
+    };
+  }
+}

--- a/packages/pot/lib/src/extensions.dart
+++ b/packages/pot/lib/src/extensions.dart
@@ -38,6 +38,7 @@ extension on _Scopes {
   void createScope() {
     add([]);
     Pot._incrementCurrentScopeNumber();
+    Pot._eventController.addEvent(PotEventKind.scopePushed, pots: []);
   }
 
   void clearScope(int index, {required bool keepScope}) {
@@ -48,9 +49,11 @@ extension on _Scopes {
 
     if (index == 0 || keepScope) {
       pots.clear();
+      Pot._eventController.addEvent(PotEventKind.scopeCleared, pots: []);
     } else {
       removeAt(index);
       Pot._decrementCurrentScopeNumber();
+      Pot._eventController.addEvent(PotEventKind.scopePopped, pots: []);
     }
   }
 
@@ -58,6 +61,7 @@ extension on _Scopes {
     final pots = this[Pot._currentScope];
     if (!pots.contains(pot)) {
       pots.add(pot);
+      Pot._eventController.addEvent(PotEventKind.addedToScope, pots: [pot]);
     }
   }
 
@@ -68,6 +72,12 @@ extension on _Scopes {
     for (var i = start; i >= 0; i--) {
       if (this[i].contains(pot)) {
         this[i].remove(pot);
+
+        Pot._eventController.addEvent(
+          PotEventKind.removedFromScope,
+          pots: [pot],
+        );
+
         break;
       }
     }

--- a/packages/pot/lib/src/pot.dart
+++ b/packages/pot/lib/src/pot.dart
@@ -301,6 +301,15 @@ class Pot<T> extends _PotBody<T> {
   /// no longer necessary. Use the function returned by this method
   /// to remove the added listener.
   ///
+  /// ```dart
+  /// final removeListener = Pot.listen((event) {
+  ///   ...
+  /// });
+  ///
+  /// // Don't forget to stop listening when it is no longer necessary.
+  /// removeListener();
+  /// ```
+  ///
   /// The event data of type [PotEvent] passed to the callback of this
   /// method is subject to change. It is advised not to use the method
   /// for purposes other than debugging.

--- a/packages/pot/lib/src/pot.dart
+++ b/packages/pot/lib/src/pot.dart
@@ -311,6 +311,11 @@ class Pot<T> extends _PotBody<T> {
   /// Whether there is a listener of Pot events.
   static bool get hasListener => _eventController.hasListener;
 
+  @internal
+  @visibleForTesting
+  // ignore: public_member_api_docs
+  static bool get $isEventControllerClosed => _eventController.isClosed;
+
   // Used from package:pottery.
   @internal
   // ignore: public_member_api_docs

--- a/packages/pot/lib/src/pot.dart
+++ b/packages/pot/lib/src/pot.dart
@@ -1,7 +1,11 @@
+import 'dart:async' show StreamController;
+
 import 'package:meta/meta.dart' show internal, sealed, visibleForTesting;
 
 import 'errors.dart';
 
+part 'event/controller.dart';
+part 'event/data.dart';
 part 'extensions.dart';
 part 'pot_body.dart';
 
@@ -12,6 +16,10 @@ typedef PotObjectFactory<T> = T Function();
 /// The signature of a callback that receives an object of type [T]
 /// to be disposed of.
 typedef PotDisposer<T> = void Function(T);
+
+/// The signature of a function that removes the listener added
+/// by `listen()`.
+typedef RemovePotListener = Future<void> Function();
 
 typedef _Scopes = List<List<_PotBody<Object?>>>;
 
@@ -114,6 +122,7 @@ class Pot<T> extends _PotBody<T> {
 
   static int _currentScope = 0;
   static final _Scopes _scopes = [[]];
+  static final _eventController = _EventController();
 
   @visibleForTesting
   // ignore: library_private_types_in_public_api, public_member_api_docs
@@ -284,5 +293,31 @@ class Pot<T> extends _PotBody<T> {
     for (var i = count; i >= 0; i--) {
       _scopes.clearScope(i, keepScope: keepScopes);
     }
+  }
+
+  /// Starts listening for events related to pots.
+  ///
+  /// This adds a listener. It should be removed when listening is
+  /// no longer necessary. Use the function returned by this method
+  /// to remove the added listener.
+  ///
+  /// The event data of type [PotEvent] passed to the callback of this
+  /// method is subject to change. It is advised not to use the method
+  /// for purposes other than debugging.
+  static RemovePotListener listen(void Function(PotEvent event) onData) {
+    return _eventController.listen(onData);
+  }
+
+  /// Whether there is a listener of Pot events.
+  static bool get hasListener => _eventController.hasListener;
+
+  // Used from package:pottery.
+  @internal
+  // ignore: public_member_api_docs
+  static void $addEvent(
+    PotEventKind kind, {
+    required Iterable<Pot<Object?>> pots,
+  }) {
+    Pot._eventController.addEvent(kind, pots: pots);
   }
 }

--- a/packages/pot/test/event_listener_test.dart
+++ b/packages/pot/test/event_listener_test.dart
@@ -19,7 +19,7 @@ void main() {
     controller?.close();
     controller = null;
     eventsCount = 0;
-    Pot.resetAll();
+    Pot.resetAll(keepScopes: false);
   });
 
   void listener(PotEvent event) {
@@ -364,7 +364,7 @@ void main() {
         controller?.stream,
         emitsInOrder([
           predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
-          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePopped),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopeCleared),
         ]),
       );
       expect(eventsCount, 2);
@@ -386,7 +386,7 @@ void main() {
           predicate<PotEvent>((v) => v.kind == PotEventKind.created),
           predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
           predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
-          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePopped),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopeCleared),
         ]),
       );
       expect(eventsCount, 6);

--- a/packages/pot/test/event_listener_test.dart
+++ b/packages/pot/test/event_listener_test.dart
@@ -1,0 +1,438 @@
+// ignore_for_file: cascade_invocations
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:pot/pot.dart';
+
+void main() {
+  StreamController<PotEvent>? controller;
+  var eventsCount = 0;
+
+  setUp(() {
+    controller = StreamController<PotEvent>();
+  });
+  tearDown(() {
+    // Don't add `await` here. Future never completes in some cases.
+    // ignore: discarded_futures
+    controller?.close();
+    controller = null;
+    eventsCount = 0;
+    Pot.resetAll();
+  });
+
+  void listener(PotEvent event) {
+    controller?.sink.add(event);
+    eventsCount++;
+  }
+
+  group('hasListener and isClosed', () {
+    test(
+      'Listening started and ended by listen() and returned callback',
+      () async {
+        expect(Pot.hasListener, isFalse);
+
+        final removeListener = Pot.listen((_) {});
+        expect(Pot.hasListener, isTrue);
+
+        await removeListener();
+        expect(Pot.hasListener, isFalse);
+      },
+    );
+
+    test('StreamController is closed when all listeners are removed', () async {
+      expect(Pot.$isEventControllerClosed, isTrue);
+
+      final removeListener = Pot.listen((_) {});
+      expect(Pot.$isEventControllerClosed, isFalse);
+
+      await removeListener();
+      expect(Pot.$isEventControllerClosed, isTrue);
+    });
+  });
+
+  group('Methods other than those for scoping', () {
+    test('dispose() without create()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot(() => 10, disposer: (_) {});
+      pot.dispose();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.disposed),
+        ]),
+      );
+      expect(eventsCount, 2);
+    });
+
+    test('create() and dispose() when pot has no disposer', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot(() => 10);
+      pot.create();
+      pot.dispose();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.disposed),
+        ]),
+      );
+      expect(eventsCount, 6);
+    });
+
+    test('create() and dispose() when pot has disposer', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot(() => 10, disposer: (_) {});
+      pot.create();
+      pot.dispose();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.disposerCalled),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.disposed),
+        ]),
+      );
+      expect(eventsCount, 7);
+    });
+
+    test('reset() without create()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot(() => 10, disposer: (_) {});
+      pot.reset();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+        ]),
+      );
+      expect(eventsCount, 1);
+    });
+
+    test('create() and reset() when pot has no disposer', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot(() => 10);
+      pot.create();
+      pot.reset();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+        ]),
+      );
+      expect(eventsCount, 5);
+    });
+
+    test('create() and reset() when pot has disposer', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot(() => 10, disposer: (_) {});
+      pot.create();
+      pot.reset();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.disposerCalled),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+        ]),
+      );
+      expect(eventsCount, 6);
+    });
+
+    test('replace() without create()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot.replaceable(() => 10, disposer: (_) {});
+      pot.replace(() => 20);
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.replaced),
+        ]),
+      );
+      expect(eventsCount, 2);
+    });
+
+    test('replace() when pot has no disposer', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot.replaceable(() => 10);
+      pot.create();
+      pot.replace(() => 20);
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.replaced),
+        ]),
+      );
+      expect(eventsCount, 4);
+    });
+
+    test('replace() when pot has disposer', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot.replaceable(() => 10, disposer: (_) {});
+      pot.create();
+      pot.replace(() => 20);
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.disposerCalled),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.replaced),
+        ]),
+      );
+      expect(eventsCount, 5);
+    });
+
+    test('resetAsPending() without create()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot.replaceable(() => 10, disposer: (_) {});
+      pot.resetAsPending();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.markedAsPending),
+        ]),
+      );
+      expect(eventsCount, 2);
+    });
+
+    test('resetAsPending() when pot has no disposer', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot.replaceable(() => 10);
+      pot.create();
+      pot.resetAsPending();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.markedAsPending),
+        ]),
+      );
+      expect(eventsCount, 6);
+    });
+
+    test('resetAsPending() when pot has disposer', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot.replaceable(() => 10, disposer: (_) {});
+      pot.create();
+      pot.resetAsPending();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.disposerCalled),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.markedAsPending),
+        ]),
+      );
+      expect(eventsCount, 7);
+    });
+  });
+
+  group('Scoping', () {
+    test('pushScope() without create()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      Pot(() => 10);
+      Pot.pushScope();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePushed),
+        ]),
+      );
+      expect(eventsCount, 2);
+    });
+
+    test('create() and pushScope()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot(() => 10);
+      pot.create();
+      Pot.pushScope();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePushed),
+        ]),
+      );
+      expect(eventsCount, 4);
+    });
+
+    test('pushScope() and create()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot(() => 10);
+      Pot.pushScope();
+      pot.create();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePushed),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+        ]),
+      );
+      expect(eventsCount, 4);
+    });
+
+    test('popScope() without create()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      Pot(() => 10);
+      Pot.popScope();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePopped),
+        ]),
+      );
+      expect(eventsCount, 2);
+    });
+
+    test('create() and popScope()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot(() => 10);
+      pot.create();
+      Pot.popScope();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePopped),
+        ]),
+      );
+      expect(eventsCount, 6);
+    });
+
+    test('pushScope(), create() and then popScope()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot(() => 10);
+      Pot.pushScope();
+      pot.create();
+      Pot.popScope();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePushed),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePopped),
+        ]),
+      );
+      expect(eventsCount, 7);
+    });
+  });
+
+  group('Emitting an object event', () {
+    test('notifyObjectUpdate()', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot = Pot.replaceable(() => 10, disposer: (_) {});
+      pot.notifyObjectUpdate();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.objectUpdated),
+        ]),
+      );
+      expect(eventsCount, 2);
+    });
+  });
+}

--- a/packages/pot/test/event_test.dart
+++ b/packages/pot/test/event_test.dart
@@ -1,0 +1,250 @@
+// ignore_for_file: cascade_invocations
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:pot/pot.dart';
+
+void main() {
+  StreamController<PotEvent>? controller;
+  final events = <PotEvent>[];
+
+  setUp(() {
+    controller = StreamController<PotEvent>();
+  });
+  tearDown(() {
+    // Future never completes in some cases if `await` is added here.
+    // ignore: discarded_futures
+    controller?.close();
+    controller = null;
+    events.clear();
+    Pot.resetAll();
+  });
+
+  void listener(PotEvent event) {
+    controller?.sink.add(event);
+    events.add(event);
+  }
+
+  group('PotEvent data other than potDescription', () {
+    test('number, time and currentScope', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final time1 = DateTime.now();
+      Pot(() => 10);
+
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      final time2 = DateTime.now();
+      Pot.pushScope();
+
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      final time3 = DateTime.now();
+      Pot.popScope();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePushed),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePopped),
+        ]),
+      );
+
+      expect(events, hasLength(3));
+      expect(events[0].number, 1);
+      expect(events[0].currentScope, 0);
+      expect(
+        events[0].time.millisecondsSinceEpoch,
+        closeTo(time1.millisecondsSinceEpoch, 3),
+      );
+      expect(events[1].number, 2);
+      expect(events[1].currentScope, 1);
+      expect(
+        events[1].time.millisecondsSinceEpoch,
+        closeTo(time2.millisecondsSinceEpoch, 3),
+      );
+      expect(events[2].number, 3);
+      expect(events[2].currentScope, 0);
+      expect(
+        events[2].time.millisecondsSinceEpoch,
+        closeTo(time3.millisecondsSinceEpoch, 3),
+      );
+    });
+
+    group('potDescription', () {
+      test('identity', () async {
+        final removeListener = Pot.listen(listener);
+        addTearDown(removeListener);
+
+        final pot = Pot(() => 10);
+
+        await expectLater(
+          controller?.stream,
+          emitsInOrder([
+            predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          ]),
+        );
+
+        expect(events, hasLength(1));
+        expect(events[0].potDescriptions, hasLength(1));
+        expect(events[0].potDescriptions[0].identity, pot.$identity());
+      });
+
+      test('isPending', () async {
+        final removeListener = Pot.listen(listener);
+        addTearDown(removeListener);
+
+        final pot = Pot.pending<int>();
+        pot.replace(() => 10);
+        pot.resetAsPending();
+
+        await expectLater(
+          controller?.stream,
+          emitsInOrder([
+            predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+            predicate<PotEvent>((v) => v.kind == PotEventKind.replaced),
+            predicate<PotEvent>((v) => v.kind == PotEventKind.markedAsPending),
+          ]),
+        );
+
+        expect(events, hasLength(3));
+        expect(events[0].potDescriptions[0].isPending, isTrue);
+        expect(events[1].potDescriptions[0].isPending, isFalse);
+        expect(events[2].potDescriptions[0].isPending, isTrue);
+      });
+
+      test('isPending is null if pot is not of type ReplaceablePot', () async {
+        final removeListener = Pot.listen(listener);
+        addTearDown(removeListener);
+
+        Pot(() => 10);
+
+        await expectLater(
+          controller?.stream,
+          emitsInOrder([
+            predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          ]),
+        );
+
+        expect(events, hasLength(1));
+        expect(events[0].potDescriptions[0].isPending, isNull);
+      });
+
+      test('isDisposed', () async {
+        final removeListener = Pot.listen(listener);
+        addTearDown(removeListener);
+
+        final pot = Pot(() => 10);
+        pot.dispose();
+
+        await expectLater(
+          controller?.stream,
+          emitsInOrder([
+            predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+            predicate<PotEvent>((v) => v.kind == PotEventKind.disposed),
+          ]),
+        );
+
+        expect(events, hasLength(2));
+        expect(events[0].potDescriptions[0].isDisposed, isFalse);
+        expect(events[1].potDescriptions[0].isDisposed, isTrue);
+      });
+
+      test('hasObject and object', () async {
+        final removeListener = Pot.listen(listener);
+        addTearDown(removeListener);
+
+        final pot = Pot(() => 10);
+        pot.create();
+        pot.reset();
+
+        await expectLater(
+          controller?.stream,
+          emitsInOrder([
+            predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+            predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+            predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+            predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+            predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+          ]),
+        );
+
+        expect(events, hasLength(5));
+        expect(events[0].potDescriptions[0].hasObject, false);
+        expect(events[0].potDescriptions[0].object, 'null');
+        expect(events[1].potDescriptions[0].hasObject, false);
+        expect(events[1].potDescriptions[0].object, 'null');
+        expect(events[2].potDescriptions[0].hasObject, true);
+        expect(events[2].potDescriptions[0].object, '10');
+        expect(events[3].potDescriptions[0].hasObject, false);
+        expect(events[3].potDescriptions[0].object, 'null');
+        expect(events[4].potDescriptions[0].hasObject, false);
+        expect(events[4].potDescriptions[0].object, 'null');
+      });
+    });
+
+    test('scope', () async {
+      final removeListener = Pot.listen(listener);
+      addTearDown(removeListener);
+
+      final pot1 = Pot(() => 10);
+      final pot2 = Pot(() => 10);
+      final pot3 = Pot(() => 10);
+      pot1.create();
+      Pot.pushScope();
+      pot2.create();
+      pot3.create();
+      Pot.resetAllInScope();
+      Pot.popScope();
+      Pot.resetAllInScope();
+
+      await expectLater(
+        controller?.stream,
+        emitsInOrder([
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.instantiated),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePushed),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.addedToScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.created),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopeCleared),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopePopped),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.removedFromScope),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.reset),
+          predicate<PotEvent>((v) => v.kind == PotEventKind.scopeCleared),
+        ]),
+      );
+
+      expect(events, hasLength(19));
+      expect(events[0].potDescriptions[0].scope, null);
+      expect(events[1].potDescriptions[0].scope, null);
+      expect(events[2].potDescriptions[0].scope, null);
+      expect(events[3].potDescriptions[0].scope, 0);
+      expect(events[4].potDescriptions[0].scope, 0);
+      expect(events[5].potDescriptions, isEmpty);
+      expect(events[6].potDescriptions[0].scope, 1);
+      expect(events[7].potDescriptions[0].scope, 1);
+      expect(events[8].potDescriptions[0].scope, 1);
+      expect(events[9].potDescriptions[0].scope, 1);
+      expect(events[10].potDescriptions[0].scope, null);
+      expect(events[11].potDescriptions[0].scope, null);
+      expect(events[12].potDescriptions[0].scope, null);
+      expect(events[13].potDescriptions[0].scope, null);
+      expect(events[14].potDescriptions, isEmpty);
+      expect(events[15].potDescriptions, isEmpty);
+      expect(events[16].potDescriptions[0].scope, null);
+      expect(events[17].potDescriptions[0].scope, null);
+      expect(events[18].potDescriptions, isEmpty);
+    });
+  });
+}

--- a/packages/pot/test/event_test.dart
+++ b/packages/pot/test/event_test.dart
@@ -19,7 +19,7 @@ void main() {
     controller?.close();
     controller = null;
     events.clear();
-    Pot.resetAll();
+    Pot.resetAll(keepScopes: false);
   });
 
   void listener(PotEvent event) {


### PR DESCRIPTION
Closes #5

This adds `hasListener` and `notifyObjectUpdate()` as well as `listen()`.

- listen()
    - A static method to start listening.
    - Callback receives data of type `PotEvent`.
    - Returns a function that is used to remove the listener.
- hasListener
    - A static getter to show whether listeners have been registered.
- notifyObjectUpdate()
    - Events of changes in the objects held in pots are not automatically emitted, so they need to be emitted manually with this method if necessary.
