### PR TITLE
Enable communication between pottery and DevTools

### DIFF
--- a/packages/pottery/lib/src/extension/communicator.dart
+++ b/packages/pottery/lib/src/extension/communicator.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: public_member_api_docs
+// coverage:ignore-file
 
 import 'dart:convert' show jsonEncode;
 import 'dart:developer' as developer;

--- a/packages/pottery/lib/src/extension/communicator.dart
+++ b/packages/pottery/lib/src/extension/communicator.dart
@@ -1,0 +1,23 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:convert' show jsonEncode;
+import 'dart:developer' as developer;
+
+class ExtensionCommunicator {
+  const ExtensionCommunicator();
+
+  void post(String kind, [Map<String, Object?> data = const {}]) {
+    developer.postEvent(kind, data);
+  }
+
+  void onRequest(
+    String methodName,
+    Map<String, Object?> Function() dataBuilder,
+  ) {
+    developer.registerExtension(methodName, (_, __) async {
+      final data = dataBuilder();
+      final json = jsonEncode(data);
+      return developer.ServiceExtensionResponse.result(json);
+    });
+  }
+}

--- a/packages/pottery/lib/src/extension/extension_manager.dart
+++ b/packages/pottery/lib/src/extension/extension_manager.dart
@@ -1,0 +1,192 @@
+// ignore: lines_longer_than_80_chars
+// ignore_for_file: implementation_imports, library_private_types_in_public_api, public_member_api_docs
+
+import 'dart:convert' show jsonEncode;
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart' show State;
+
+import 'package:pot/pot.dart';
+import 'package:pot/src/private/static.dart';
+import 'package:pot/src/private/utils.dart';
+
+import '../local_pottery.dart';
+import '../pottery.dart';
+import '../utils.dart';
+
+typedef _Pots = Iterable<Pot<Object?>>;
+typedef _Potteries = Map<State<Pottery>, ({DateTime time, _Pots pots})>;
+typedef _LocalPotteries = Map<State<LocalPottery>,
+    ({DateTime time, List<({Pot<Object?> pot, Object? localObject})> list})>;
+
+class PotteryExtensionManager {
+  PotteryExtensionManager._() {
+    _initialize();
+  }
+
+  factory PotteryExtensionManager.createSingle() {
+    return _instance ??= PotteryExtensionManager._();
+  }
+
+  static PotteryExtensionManager? _instance;
+
+  bool _initialized = false;
+  Future<void> Function()? _listenerRemover;
+
+  final _Potteries _potteries = {};
+  final _LocalPotteries _localPotteries = {};
+
+  @visibleForTesting
+  _Potteries get potteries => Map.of(_potteries);
+  @visibleForTesting
+  _LocalPotteries get localPotteries => Map.of(_localPotteries);
+
+  void dispose() {
+    _listenerRemover?.call();
+    _listenerRemover = null;
+
+    _instance = null;
+    _initialized = false;
+
+    _potteries.clear();
+    _localPotteries.clear();
+  }
+
+  void _runIfDebugAndInitialized(void Function() func) {
+    runIfDebug(() {
+      if (_initialized) {
+        func();
+      }
+    });
+  }
+
+  void _initialize() {
+    if (_initialized) {
+      return;
+    }
+    _initialized = true;
+
+    _runIfDebugAndInitialized(() {
+      developer.postEvent('pottery:initialize', {});
+
+      _listenerRemover = Pot.listen((event) {
+        if (!event.kind.isScopeEvent) {
+          developer.postEvent('pottery:pot_event', event.toMap());
+        }
+      });
+
+      developer.registerExtension(
+        'ext.pottery.getPots',
+        (_, __) async {
+          return developer.ServiceExtensionResponse.result(
+            jsonEncode({
+              for (final (pot, time) in StaticPot.allInstances.records)
+                pot.identity(): {
+                  'time': time.microsecondsSinceEpoch,
+                  'potDescription': PotDescription.fromPot(pot).toMap(),
+                },
+            }),
+          );
+        },
+      );
+      developer.registerExtension(
+        'ext.pottery.getPotteries',
+        (_, __) async {
+          return developer.ServiceExtensionResponse.result(
+            jsonEncode({
+              for (final (state, data) in _potteries.records)
+                state.widgetIdentity(): {
+                  'time': data.time.microsecondsSinceEpoch,
+                  'potDescriptions': [
+                    for (final pot in data.pots)
+                      PotDescription.fromPot(pot).toMap(),
+                  ],
+                },
+            }),
+          );
+        },
+      );
+      developer.registerExtension(
+        'ext.pottery.getLocalPotteries',
+        (_, __) async {
+          return developer.ServiceExtensionResponse.result(
+            jsonEncode({
+              for (final (state, data) in _localPotteries.records)
+                state.widgetIdentity(): {
+                  'time': data.time.microsecondsSinceEpoch,
+                  'objects': [
+                    for (final v in data.list)
+                      {
+                        // ignore: invalid_use_of_internal_member
+                        'potIdentity': v.pot.identity(),
+                        'object': '${v.localObject}',
+                      },
+                  ],
+                },
+            }),
+          );
+        },
+      );
+    });
+  }
+
+  void onPotteryCreated(State<Pottery> state, _Pots pots) {
+    _runIfDebugAndInitialized(() {
+      StaticPot.eventHandler.addEvent(
+        PotEventKind.potteryCreated,
+        pots: pots,
+      );
+
+      _potteries[state] = (time: DateTime.now(), pots: pots);
+    });
+  }
+
+  void onPotteryRemoved(State<Pottery> state, _Pots pots) {
+    _runIfDebugAndInitialized(() {
+      StaticPot.eventHandler.addEvent(
+        PotEventKind.potteryRemoved,
+        pots: pots,
+      );
+
+      _potteries.remove(state);
+    });
+  }
+
+  void onLocalPotteryCreated(
+    State<LocalPottery> state,
+    LocalPotteryObjects objects,
+  ) {
+    _runIfDebugAndInitialized(() {
+      StaticPot.eventHandler.addEvent(
+        PotEventKind.localPotteryCreated,
+        pots: objects.keys,
+      );
+
+      _localPotteries[state] = (
+        time: DateTime.now(),
+        list: [
+          for (final (pot, object) in objects.records)
+            // The object is converted to a string when used, but the
+            // conversion must not be here. Having in the form of a
+            // fixed string means newer changes will not be reflected.
+            (pot: pot, localObject: object),
+        ],
+      );
+    });
+  }
+
+  void onLocalPotteryRemoved(
+    State<LocalPottery> state,
+    LocalPotteryObjects objects,
+  ) {
+    _runIfDebugAndInitialized(() {
+      StaticPot.eventHandler.addEvent(
+        PotEventKind.localPotteryRemoved,
+        pots: objects.keys,
+      );
+
+      _localPotteries.remove(state);
+    });
+  }
+}

--- a/packages/pottery/lib/src/local_pottery.dart
+++ b/packages/pottery/lib/src/local_pottery.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 
 import 'package:pot/pot.dart';
 
+import 'extension/extension_manager.dart';
 import 'pottery.dart';
 import 'utils.dart';
 
@@ -176,6 +177,7 @@ class LocalPottery extends StatefulWidget {
 
 class _LocalPotteryState extends State<LocalPottery> {
   late final LocalPotteryObjects _objects;
+  PotteryExtensionManager? _extensionManager;
 
   @override
   void initState() {
@@ -185,11 +187,17 @@ class _LocalPotteryState extends State<LocalPottery> {
       for (final (pot, objectFactory) in widget.pots.records)
         pot: objectFactory(),
     };
+
+    runIfDebug(() {
+      _extensionManager = PotteryExtensionManager.createSingle()
+        ..onLocalPotteryCreated(this, _objects);
+    });
   }
 
   @override
   void dispose() {
     widget.disposer?.call(_objects);
+    _extensionManager?.onLocalPotteryRemoved(this, _objects);
     super.dispose();
   }
 
@@ -251,6 +259,8 @@ extension NearestPotOf<T> on Pot<T> {
 
     if (!found) {
       context.visitAncestorElements((element) {
+        // Suppresses false positive warning
+        // ignore: unnecessary_statements
         (:object, :found) = _findObject(element);
         return !found;
       });

--- a/packages/pottery/lib/src/pottery.dart
+++ b/packages/pottery/lib/src/pottery.dart
@@ -3,7 +3,9 @@ import 'package:flutter/widgets.dart';
 
 import 'package:pot/pot.dart';
 
+import 'extension/extension_manager.dart';
 import 'local_pottery.dart';
+import 'utils.dart';
 
 /// The signature of a map consisting of replaceable pots and factories.
 typedef PotReplacements
@@ -77,9 +79,16 @@ class Pottery extends StatefulWidget {
 }
 
 class _PotteryState extends State<Pottery> {
+  PotteryExtensionManager? _extensionManager;
+
   @override
   void initState() {
     super.initState();
+
+    runIfDebug(() {
+      _extensionManager = PotteryExtensionManager.createSingle()
+        ..onPotteryCreated(this, widget.pots.keys);
+    });
     widget.pots.forEach((pot, factory) => pot.replace(factory));
   }
 
@@ -90,6 +99,7 @@ class _PotteryState extends State<Pottery> {
     widget.pots.keys.toList().reversed.forEach((pot) {
       pot.resetAsPending();
     });
+    _extensionManager?.onPotteryRemoved(this, widget.pots.keys);
 
     super.dispose();
   }

--- a/packages/pottery/lib/src/utils.dart
+++ b/packages/pottery/lib/src/utils.dart
@@ -1,7 +1,32 @@
 // ignore_for_file: public_member_api_docs
 
+import 'package:flutter/widgets.dart' show State;
+
 extension MapToRecords<K, V> on Map<K, V> {
   List<(K, V)> get records => [
         for (final MapEntry(:key, :value) in entries) (key, value),
       ];
+}
+
+extension ObjectShortHash on Object {
+  String shortHash() {
+    return hashCode.toUnsigned(20).toRadixString(16).padLeft(5, '0');
+  }
+}
+
+extension WidgetIdentity on State {
+  String widgetIdentity() {
+    // ignore: no_runtimeType_toString
+    return '${widget.runtimeType}#${widget.shortHash()}';
+  }
+}
+
+void runIfDebug(void Function() func) {
+  // ignore: prefer_asserts_with_message
+  assert(
+    () {
+      func();
+      return true;
+    }(),
+  );
 }

--- a/packages/pottery/test/extension_test.dart
+++ b/packages/pottery/test/extension_test.dart
@@ -1,0 +1,326 @@
+import 'dart:convert' show jsonEncode;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:pot/src/private/static.dart';
+import 'package:pot/src/private/utils.dart';
+
+import 'package:pottery/pottery.dart';
+import 'package:pottery/src/extension/extension_manager.dart';
+import 'package:pottery/src/utils.dart';
+
+import 'spy_communicator.dart';
+import 'utils.dart';
+
+class Foo {
+  Foo([this.value]);
+  int? value;
+
+  @override
+  String toString() => 'Foo($value)';
+}
+
+void main() {
+  late PotteryExtensionManager extensionManager;
+  late SpyExtensionCommunicator communicator;
+
+  ReplaceablePot<int>? pot1;
+  ReplaceablePot<int>? pot2;
+  ReplaceablePot<Foo>? fooPot;
+
+  setUp(() {
+    communicator = SpyExtensionCommunicator();
+    extensionManager =
+        PotteryExtensionManager.createSingle(testCommunicator: communicator);
+  });
+  tearDown(() {
+    extensionManager.dispose();
+    communicator.dispose();
+
+    pot1?.dispose();
+    pot1 = null;
+    pot2?.dispose();
+    pot2 = null;
+    fooPot?.dispose();
+    fooPot = null;
+  });
+
+  group('Initialization', () {
+    test('"pottery:initialize" on initialization', () {
+      expect(communicator.log, hasLength(1));
+      expect(communicator.log[0], ('pottery:initialize', '{}'));
+    });
+
+    test('Calling createSingle() many times does not create new manager', () {
+      final extensionManager2 = PotteryExtensionManager.createSingle(
+        testCommunicator: communicator,
+      );
+      expect(extensionManager2, extensionManager);
+      expect(communicator.log, hasLength(1));
+      expect(communicator.log[0], ('pottery:initialize', '{}'));
+    });
+  });
+
+  group('Scoping of package:pot', () {
+    testWidgets('Events related to scoping is ignored', (tester) async {
+      final events = <PotEventKind>[];
+      final listenerRemover = Pot.listen((event) => events.add(event.kind));
+      addTearDown(listenerRemover);
+
+      pot1 = Pot.replaceable(() => 10);
+      Pot.pushScope();
+
+      await tester.pump();
+
+      expect(events, [PotEventKind.instantiated, PotEventKind.scopePushed]);
+      expect(communicator.log, hasLength(2));
+      expect(communicator.log[0], ('pottery:initialize', '{}'));
+      expect(communicator.log[1], logContainsEvent('instantiated'));
+    });
+  });
+
+  group('Response to request from extension', () {
+    testWidgets(
+      '"ext.pottery.getPots" responses with correct data',
+      (tester) async {
+        pot1 = Pot.pending();
+        pot2 = Pot.pending();
+
+        await tester.pump();
+
+        expect(communicator.log, hasLength(3));
+        expect(communicator.log[0], ('pottery:initialize', '{}'));
+        expect(
+          communicator.log[1],
+          logContainsEvent('instantiated', identity: pot1!.identity()),
+        );
+        expect(
+          communicator.log[2],
+          logContainsEvent('instantiated', identity: pot2!.identity()),
+        );
+
+        communicator.request('ext.pottery.getPots');
+
+        expect(communicator.log, hasLength(4));
+        expect(
+          communicator.log[3],
+          (
+            'ext.pottery.getPots',
+            jsonEncode({
+              pot1!.identity(): {
+                'time': StaticPot.allInstances[pot1]!.microsecondsSinceEpoch,
+                'potDescription': PotDescription.fromPot(pot1!).toMap(),
+              },
+              pot2!.identity(): {
+                'time': StaticPot.allInstances[pot2]!.microsecondsSinceEpoch,
+                'potDescription': PotDescription.fromPot(pot2!).toMap(),
+              },
+            }),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      '"ext.pottery.getPotteries" responses with correct data',
+      (tester) async {
+        pot1 = Pot.pending<int>();
+        pot2 = Pot.pending<int>();
+
+        await tester.pumpWidget(
+          Pottery(
+            pots: {
+              pot1!: () => 10,
+              pot2!: () => 20,
+            },
+            builder: (context) {
+              pot1!.create();
+              pot2!.create();
+              return const SizedBox.shrink();
+            },
+          ),
+        );
+
+        final desc1 = PotDescription.fromPot(pot1!);
+        final desc2 = PotDescription.fromPot(pot2!);
+        expect(desc1.object, '10');
+        expect(desc2.object, '20');
+
+        expect(communicator.log, hasLength(8));
+        expect(communicator.log[0], ('pottery:initialize', '{}'));
+        expect(communicator.log[1], logContainsEvent('instantiated'));
+        expect(communicator.log[2], logContainsEvent('instantiated'));
+        expect(communicator.log[3], logContainsEvent('potteryCreated'));
+        expect(communicator.log[4], logContainsEvent('replaced'));
+        expect(communicator.log[5], logContainsEvent('replaced'));
+        expect(communicator.log[6], logContainsEvent('created'));
+        expect(communicator.log[7], logContainsEvent('created'));
+
+        communicator.request('ext.pottery.getPotteries');
+
+        expect(communicator.log, hasLength(9));
+        expect(
+          communicator.log[8],
+          (
+            'ext.pottery.getPotteries',
+            jsonEncode({
+              for (final (state, data) in extensionManager.potteries.records)
+                state.widgetIdentity(): {
+                  'time': data.time.microsecondsSinceEpoch,
+                  'potDescriptions': [
+                    desc1.toMap(),
+                    desc2.toMap(),
+                  ],
+                },
+            }),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      '"ext.pottery.getLocalPotteries" responses with correct data',
+      (tester) async {
+        pot1 = Pot.pending<int>();
+        pot2 = Pot.pending<int>();
+
+        await tester.pumpWidget(
+          LocalPottery(
+            pots: {
+              pot1!: () => 10,
+              pot2!: () => 20,
+            },
+            builder: (context) => const SizedBox.shrink(),
+          ),
+        );
+
+        expect(communicator.log, hasLength(4));
+        expect(communicator.log[0], ('pottery:initialize', '{}'));
+        expect(communicator.log[1], logContainsEvent('instantiated'));
+        expect(communicator.log[2], logContainsEvent('instantiated'));
+        expect(communicator.log[3], logContainsEvent('localPotteryCreated'));
+
+        communicator.request('ext.pottery.getLocalPotteries');
+
+        expect(communicator.log, hasLength(5));
+        expect(
+          communicator.log[4],
+          (
+            'ext.pottery.getLocalPotteries',
+            jsonEncode({
+              for (final (state, data)
+                  in extensionManager.localPotteries.records)
+                state.widgetIdentity(): {
+                  'time': data.time.microsecondsSinceEpoch,
+                  'objects': [
+                    {
+                      'potIdentity': pot1!.identity(),
+                      'object': '10',
+                    },
+                    {
+                      'potIdentity': pot2!.identity(),
+                      'object': '20',
+                    },
+                  ],
+                },
+            }),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'Response reflects updates of pot after creation of Pottery',
+      (tester) async {
+        fooPot = Pot.pending<Foo>();
+
+        await tester.pumpWidget(
+          Pottery(
+            pots: {
+              fooPot!: () => Foo(20),
+            },
+            builder: (context) {
+              fooPot!().value = 30;
+              return const SizedBox.shrink();
+            },
+          ),
+        );
+
+        final desc = PotDescription.fromPot(fooPot!);
+        expect(desc.object, 'Foo(30)');
+
+        expect(communicator.log, hasLength(5));
+        expect(communicator.log[0], ('pottery:initialize', '{}'));
+        expect(communicator.log[1], logContainsEvent('instantiated'));
+        expect(communicator.log[2], logContainsEvent('potteryCreated'));
+        expect(communicator.log[3], logContainsEvent('replaced'));
+        expect(communicator.log[4], logContainsEvent('created'));
+
+        communicator.request('ext.pottery.getPotteries');
+
+        expect(communicator.log, hasLength(6));
+        expect(
+          communicator.log[5],
+          (
+            'ext.pottery.getPotteries',
+            jsonEncode({
+              for (final (state, data) in extensionManager.potteries.records)
+                state.widgetIdentity(): {
+                  'time': data.time.microsecondsSinceEpoch,
+                  'potDescriptions': [desc.toMap()],
+                },
+            }),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'Response reflects updates of pot after creation of LocalPottery',
+      (tester) async {
+        fooPot = Pot.pending<Foo>();
+
+        await tester.pumpWidget(
+          LocalPottery(
+            pots: {
+              fooPot!: () => Foo(20),
+            },
+            builder: (context) {
+              fooPot!.of(context).value = 30;
+              return const SizedBox.shrink();
+            },
+          ),
+        );
+
+        expect(communicator.log, hasLength(3));
+        expect(communicator.log[0], ('pottery:initialize', '{}'));
+        expect(communicator.log[1], logContainsEvent('instantiated'));
+        expect(communicator.log[2], logContainsEvent('localPotteryCreated'));
+
+        communicator.request('ext.pottery.getLocalPotteries');
+
+        expect(communicator.log, hasLength(4));
+        expect(
+          communicator.log[3],
+          (
+            'ext.pottery.getLocalPotteries',
+            jsonEncode({
+              for (final (state, data)
+                  in extensionManager.localPotteries.records)
+                state.widgetIdentity(): {
+                  'time': data.time.microsecondsSinceEpoch,
+                  'objects': [
+                    {
+                      'potIdentity': fooPot!.identity(),
+                      'object': 'Foo(30)',
+                    },
+                  ],
+                },
+            }),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/packages/pottery/test/local_pottery_test.dart
+++ b/packages/pottery/test/local_pottery_test.dart
@@ -6,10 +6,6 @@ import 'package:pottery/pottery.dart';
 
 import 'widgets.dart';
 
-ReplaceablePot<Foo>? fooPot;
-ReplaceablePot<Bar>? barPot;
-ReplaceablePot<Object?>? nullablePot;
-
 class Foo {
   const Foo([this.value]);
   final int? value;
@@ -20,9 +16,16 @@ class Bar {
 }
 
 void main() {
-  setUp(() {
+  ReplaceablePot<Foo>? fooPot;
+  ReplaceablePot<Bar>? barPot;
+  ReplaceablePot<Object?>? nullablePot;
+
+  tearDown(() {
+    fooPot?.dispose();
     fooPot = null;
+    barPot?.dispose();
     barPot = null;
+    nullablePot?.dispose();
     nullablePot = null;
   });
 

--- a/packages/pottery/test/pottery_test.dart
+++ b/packages/pottery/test/pottery_test.dart
@@ -6,10 +6,6 @@ import 'package:pottery/pottery.dart';
 
 import 'widgets.dart';
 
-ReplaceablePot<Foo>? fooPot;
-ReplaceablePot<Bar>? barPot;
-ReplaceablePot<Object?>? nullablePot;
-
 class Foo {
   const Foo([this.value]);
   final int? value;
@@ -20,9 +16,16 @@ class Bar {
 }
 
 void main() {
-  setUp(() {
+  ReplaceablePot<Foo>? fooPot;
+  ReplaceablePot<Bar>? barPot;
+  ReplaceablePot<Object?>? nullablePot;
+
+  tearDown(() {
+    fooPot?.dispose();
     fooPot = null;
+    barPot?.dispose();
     barPot = null;
+    nullablePot?.dispose();
     nullablePot = null;
   });
 
@@ -106,6 +109,12 @@ void main() {
     (tester) async {
       fooPot = Pot.pending<Foo>(disposer: (_) => barPot?.call());
       barPot = Pot.pending<Bar>();
+
+      addTearDown(() {
+        // A factory must be set so that dispose does not
+        // throw when clean-up runs at the end of the test.
+        barPot?.replace(Bar.new);
+      });
 
       await tester.pumpWidget(
         TestPottery(

--- a/packages/pottery/test/spy_communicator.dart
+++ b/packages/pottery/test/spy_communicator.dart
@@ -1,0 +1,35 @@
+import 'dart:convert' show jsonEncode;
+
+import 'package:pottery/src/extension/communicator.dart';
+
+typedef SpyLog = (String label, String? data);
+
+class SpyExtensionCommunicator implements ExtensionCommunicator {
+  final methods = <String, String Function()>{};
+  final log = <SpyLog>[];
+
+  void dispose() {
+    methods.clear();
+    log.clear();
+  }
+
+  @override
+  void post(String kind, [Map<String, Object?> data = const {}]) {
+    log.add((kind, jsonEncode(data)));
+  }
+
+  @override
+  void onRequest(
+    String methodName,
+    Map<String, Object?> Function() dataBuilder,
+  ) {
+    methods[methodName] = () => jsonEncode(dataBuilder());
+  }
+
+  void request(String methodName) {
+    final method = methods[methodName];
+    if (method != null) {
+      log.add((methodName, method()));
+    }
+  }
+}

--- a/packages/pottery/test/utils.dart
+++ b/packages/pottery/test/utils.dart
@@ -1,0 +1,40 @@
+import 'dart:convert' show jsonDecode;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:pot/pot.dart';
+
+import 'spy_communicator.dart';
+
+Matcher logContainsEvent(String kind, {String? identity}) =>
+    _LogContainsEvent(kind, identity);
+
+class _LogContainsEvent extends Matcher {
+  const _LogContainsEvent(this.kind, this.identity);
+
+  final String kind;
+  final String? identity;
+
+  @override
+  bool matches(Object? item, Map<Object?, Object?> matchState) {
+    if (item is SpyLog) {
+      final map = jsonDecode(item.$2 ?? '') as Map<String, Object?>;
+      final event = PotEvent.fromMap(map);
+
+      return event.kind.name == kind &&
+          (identity == null ||
+              event.potDescriptions.elementAtOrNull(0)?.identity == identity);
+    }
+    return false;
+  }
+
+  @override
+  Description describe(Description description) {
+    return description
+        .add('log contains an event with the values of ')
+        .addDescriptionOf({
+      'kind': kind,
+      if (identity != null) 'identity': identity,
+    });
+  }
+}


### PR DESCRIPTION
#9

This adds functionality to enable communication, and does not contain the app to be shown in DevTools.

- Add `PotteryExtensionManager`.
- State of `Pottery` is stored in a map in the manager when it is created, and removed when it is disposed.
- Same for `LocalPottery`.
- Posts events to the extension event stream with the following kind names:
    - pottery:initialize
    - pottery:pot_event
- Returns data in response to requests from DevTools that come with the following method names:
    - ext.pottery.getPots
    - ext.pottery.getPotteries
    - ext.pottery.getLocalPotteries
