### PR TITLE
Avoid resetting active pot in stale Pottery dispose when pot factory has changed

### DIFF
--- a/packages/pot/lib/src/parts/pot_body.dart
+++ b/packages/pot/lib/src/parts/pot_body.dart
@@ -36,6 +36,11 @@ class _PotBody<T> {
   /// a pot is associated with a certain scope as expected.
   int? get scope => _scope;
 
+  /// Internal API for Pot and related packages.
+  /// Intentionally undocumented for external use.
+  @internal
+  int? get factoryHashCode => _factory.hashCode;
+
   Pot<T> get _pot => this as Pot<T>;
 
   @override

--- a/packages/pot/lib/src/pot.dart
+++ b/packages/pot/lib/src/pot.dart
@@ -1,4 +1,5 @@
-import 'package:meta/meta.dart' show immutable, sealed, visibleForTesting;
+import 'package:meta/meta.dart'
+    show immutable, internal, sealed, visibleForTesting;
 
 import 'errors.dart';
 import 'event.dart';

--- a/packages/pottery/lib/src/pottery.dart
+++ b/packages/pottery/lib/src/pottery.dart
@@ -49,6 +49,12 @@ import 'utils.dart';
 /// > [Pottery] does not bind pots to the widget tree. It only uses the
 /// > lifecycle of itself in the tree to control the lifetime of pots'
 /// > content, which is an important difference from [LocalPottery].
+///
+/// > [!WARNING]
+/// > Do not manually reset or replace a pot used by a `Pottery`. Also,
+/// > do not let a `Pottery` take over pots already managed by another
+/// > `Pottery`. Doing so skips the reset that should happen when the
+/// > original `Pottery` is disposed.
 /// {@endtemplate}
 class Pottery extends StatefulWidget {
   /// Creates a [Pottery] widget that limits the lifespan of the

--- a/packages/pottery/lib/src/pottery.dart
+++ b/packages/pottery/lib/src/pottery.dart
@@ -84,6 +84,8 @@ class Pottery extends StatefulWidget {
 }
 
 class _PotteryState extends State<Pottery> {
+  final Map<ReplaceablePot<Object?>, int> _factoryHashCodes = {};
+
   PotteryExtensionManager? _extensionManager;
 
   @override
@@ -97,19 +99,37 @@ class _PotteryState extends State<Pottery> {
 
     for (final repl in widget.overrides) {
       repl.pot.replace(repl.factory);
+      _factoryHashCodes[repl.pot] = repl.factory.hashCode;
     }
   }
 
   @override
   void dispose() {
-    final pots = widget.overrides.map((repl) => repl.pot);
+    final pots = widget.overrides.map((v) => v.pot).toList();
+    final removedPots = <ReplaceablePot<Object?>>[];
 
     // Some pots may depend on other pots located earlier in
     // the collection, so they must be reset in reverse order.
     for (var i = pots.length - 1; i >= 0; i--) {
-      pots.elementAt(i).resetAsPending();
+      final pot = pots[i];
+
+      // If the factory's hash code has changed, another Pottery has
+      // probably replaced the factory. In that case, the pot has already
+      // been reset by the replacement. Resetting it here would make the
+      // pot unusable for the new screen, so it must be skipped.
+      //
+      // This can happen when a new instance of the same Pottery is
+      // created before the previous screen finishes its closing animation.
+      // Then dispose() of the old instance may run after initState() of
+      // the new one.
+      //
+      // ignore: invalid_use_of_internal_member
+      if (pot.factoryHashCode == _factoryHashCodes[pot]) {
+        pot.resetAsPending();
+        removedPots.add(pot);
+      }
     }
-    _extensionManager?.onPotteryRemoved(this, pots);
+    _extensionManager?.onPotteryRemoved(this, removedPots);
 
     super.dispose();
   }

--- a/packages/pottery/test/pottery_test.dart
+++ b/packages/pottery/test/pottery_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart' show DiagnosticPropertiesBuilder;
+import 'package:flutter/material.dart' show ElevatedButton;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -124,6 +125,72 @@ void main() {
     );
     expect(nullablePot!(), isNull);
   });
+
+  testWidgets(
+    'Pot reset is skipped when Pottery is disposed if another Pottery has '
+    "replaced the pot's factory",
+    (tester) async {
+      final disposedObjects = <String>[];
+      fooPot = Pot.pending(
+        disposer: (v) => disposedObjects.add('Foo(${v.value})'),
+      );
+      barPot = Pot.pending(
+        disposer: (v) => disposedObjects.add('Bar()'),
+      );
+
+      var count = 0;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: StatefulBuilder(
+            builder: (context, setState) {
+              return Column(
+                children: [
+                  if (count <= 1)
+                    Pottery(
+                      overrides: [
+                        fooPot!.set(() => const Foo(1)),
+                        barPot!.set(Bar.new),
+                      ],
+                      builder: (context) => const SizedBox.shrink(),
+                    ),
+                  if (count == 1)
+                    Pottery(
+                      overrides: [
+                        fooPot!.set(() => const Foo(2)),
+                      ],
+                      builder: (context) => const SizedBox.shrink(),
+                    ),
+                  ElevatedButton(
+                    onPressed: () => setState(() => count += 1),
+                    child: const Text(''),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      );
+
+      fooPot!.create();
+      barPot!.create();
+      expect(disposedObjects, isEmpty);
+
+      final buttonFinder = find.byType(ElevatedButton);
+      await tester.tap(buttonFinder);
+      await tester.pump();
+
+      fooPot!.create();
+      barPot!.create();
+      expect(disposedObjects, ['Foo(1)']);
+
+      await tester.tap(buttonFinder);
+      await tester.pump();
+
+      expect(disposedObjects, unorderedEquals(['Foo(1)', 'Bar()', 'Foo(2)']));
+    },
+  );
 
   testWidgets(
     'PotNotReadyException is thrown when Pottery calls reset() '


### PR DESCRIPTION
Fixes #15 

This PR fixes `Pottery` disposal behavior by checking whether each pot's factory hash code has changed.

If a factory has already been replaced, the previous `Pottery` instance's `dispose()` skips resetting the pots used by the reopened screen.